### PR TITLE
Route53ホストゾーンのTerraform構成を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -47,19 +47,23 @@ Webブラウザ上で完結し、バックエンドサーバーを必要とし�
 ### インフラストラクチャのデプロイ
 
 #### ステージング環境
+(例)
 ```bash
 cd infrastructure/stg
-terraform init
-terraform plan
-terraform apply
+aws sso login --profile terraform-static-stg
+export AWS_PROFILE=terraform-static-stg; terraform init
+export AWS_PROFILE=terraform-static-stg; terraform plan
+export AWS_PROFILE=terraform-static-stg; terraform apply
 ```
 
 #### 本番環境
+(例)
 ```bash
 cd infrastructure/prod
-terraform init
-terraform plan
-terraform apply
+aws sso login --profile terraform-static-prod
+export AWS_PROFILE=terraform-static-prod; terraform init
+export AWS_PROFILE=terraform-static-prod; terraform plan
+export AWS_PROFILE=terraform-static-prod; terraform apply
 ```
 
 ## 開発フロー

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,137 @@
+# Infrastructure
+
+このディレクトリには、AWS上にデプロイするためのTerraform構成が含まれています。
+
+## ディレクトリ構成
+
+```
+infrastructure/
+├── modules/
+│   └── route53-hosted-zone/    # Route53ホストゾーンの共通モジュール
+│       ├── main.tf
+│       ├── variables.tf
+│       └── outputs.tf
+├── stg/                         # ステージング環境
+│   ├── main.tf
+│   ├── variables.tf
+│   └── outputs.tf
+├── prod/                        # 本番環境
+│   ├── main.tf
+│   ├── variables.tf
+│   └── outputs.tf
+└── README.md
+```
+
+## 環境
+
+### ステージング環境 (stg)
+- ドメイン: `stg-static.makedara.work`
+- 用途: 開発・検証
+
+### 本番環境 (prod)
+- ドメイン: `static.makedara.work`
+- 用途: 本番運用
+
+## State管理
+
+TerraformのstateファイルはS3バケットで管理されています。各環境で以下のリソースが使用されます:
+
+### ステージング環境
+- S3バケット: `terraform-state-stg-[uuid]`
+- リージョン: `ap-northeast-1`
+
+### 本番環境
+- S3バケット: `terraform-state-prod-[uuid]`
+- リージョン: `ap-northeast-1`
+
+stateファイルは暗号化されて保存され、S3ネイティブのロック機構（`use_lockfile`）で同時実行を防止します。
+
+> **Note**: Terraform 1.10以降では、S3ネイティブのステートロック機能を使用しており、DynamoDBテーブルは不要です。
+
+### 初回セットアップ
+
+初めてTerraformを使用する場合、S3バケットを事前に作成する必要があります:
+
+```bash
+# ステージング環境用
+aws s3api create-bucket \
+  --bucket terraform-state-stg-[uuid] \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+aws s3api put-bucket-versioning \
+  --bucket terraform-state-stg-[uuid] \
+  --versioning-configuration Status=Enabled
+
+# 本番環境用
+aws s3api create-bucket \
+  --bucket terraform-state-prod-[uuid] \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+aws s3api put-bucket-versioning \
+  --bucket terraform-state-prod-[uuid] \
+  --versioning-configuration Status=Enabled
+```
+
+※ `[uuid]` 部分は実際のUUIDに置き換えてください。
+
+## 使用方法
+
+### 初期化
+
+各環境ディレクトリで以下を実行します:
+
+```bash
+# ステージング環境
+cd infrastructure/stg
+terraform init
+
+# 本番環境
+cd infrastructure/prod
+terraform init
+```
+
+### 実行計画の確認
+
+```bash
+terraform plan
+```
+
+### リソースの適用
+
+```bash
+terraform apply
+```
+
+実行後、ネームサーバー情報が出力されるので、ドメインレジストラ側でNSレコードを設定してください。
+
+### リソースの削除
+
+```bash
+terraform destroy
+```
+
+## モジュール
+
+### route53-hosted-zone
+
+Route53のホストゾーンを作成する共通モジュールです。
+
+#### 入力変数
+
+- `domain_name` (required): ホストゾーンのドメイン名
+- `environment` (required): 環境名 (staging, production など)
+- `tags` (optional): 追加のタグ
+
+#### 出力
+
+- `zone_id`: ホストゾーンID
+- `name_servers`: ネームサーバーのリスト
+- `zone_arn`: ホストゾーンのARN
+
+## 注意事項
+
+- 各環境は独立したAWSアカウントで管理されることを想定しています
+- Terraform実行前には必ず適切なAWS認証情報が設定されていることを確認してください
+- 本番環境への変更は特に慎重に行ってください

--- a/infrastructure/modules/route53-hosted-zone/main.tf
+++ b/infrastructure/modules/route53-hosted-zone/main.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+
+  tags = merge(
+    {
+      Name        = var.domain_name
+      Environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/infrastructure/modules/route53-hosted-zone/outputs.tf
+++ b/infrastructure/modules/route53-hosted-zone/outputs.tf
@@ -1,0 +1,14 @@
+output "zone_id" {
+  description = "The hosted zone ID"
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "name_servers" {
+  description = "The name servers for the hosted zone"
+  value       = aws_route53_zone.main.name_servers
+}
+
+output "zone_arn" {
+  description = "The ARN of the hosted zone"
+  value       = aws_route53_zone.main.arn
+}

--- a/infrastructure/modules/route53-hosted-zone/variables.tf
+++ b/infrastructure/modules/route53-hosted-zone/variables.tf
@@ -1,0 +1,15 @@
+variable "domain_name" {
+  description = "The domain name for the hosted zone"
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment name (e.g., staging, production)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the hosted zone"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/prod/.terraform.lock.hcl
+++ b/infrastructure/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/prod/main.tf
+++ b/infrastructure/prod/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "terraform-state-prod-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = "production"
+      ManagedBy   = "Terraform"
+      Project     = "static-app"
+    }
+  }
+}
+
+module "hosted_zone" {
+  source = "../modules/route53-hosted-zone"
+
+  domain_name = var.domain_name
+  environment = "production"
+
+  tags = {
+    Project = "static-app"
+  }
+}

--- a/infrastructure/prod/outputs.tf
+++ b/infrastructure/prod/outputs.tf
@@ -1,0 +1,14 @@
+output "hosted_zone_id" {
+  description = "The ID of the Route53 hosted zone"
+  value       = module.hosted_zone.zone_id
+}
+
+output "hosted_zone_name_servers" {
+  description = "The name servers for the hosted zone"
+  value       = module.hosted_zone.name_servers
+}
+
+output "hosted_zone_arn" {
+  description = "The ARN of the hosted zone"
+  value       = module.hosted_zone.zone_arn
+}

--- a/infrastructure/prod/variables.tf
+++ b/infrastructure/prod/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "domain_name" {
+  description = "Domain name for the hosted zone"
+  type        = string
+  default     = "static.makedara.work"
+}

--- a/infrastructure/stg/.terraform.lock.hcl
+++ b/infrastructure/stg/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/stg/main.tf
+++ b/infrastructure/stg/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "terraform-state-stg-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = "staging"
+      ManagedBy   = "Terraform"
+      Project     = "static-app"
+    }
+  }
+}
+
+module "hosted_zone" {
+  source = "../modules/route53-hosted-zone"
+
+  domain_name = var.domain_name
+  environment = "staging"
+
+  tags = {
+    Project = "static-app"
+  }
+}

--- a/infrastructure/stg/outputs.tf
+++ b/infrastructure/stg/outputs.tf
@@ -1,0 +1,14 @@
+output "hosted_zone_id" {
+  description = "The ID of the Route53 hosted zone"
+  value       = module.hosted_zone.zone_id
+}
+
+output "hosted_zone_name_servers" {
+  description = "The name servers for the hosted zone"
+  value       = module.hosted_zone.name_servers
+}
+
+output "hosted_zone_arn" {
+  description = "The ARN of the hosted zone"
+  value       = module.hosted_zone.zone_arn
+}

--- a/infrastructure/stg/variables.tf
+++ b/infrastructure/stg/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "domain_name" {
+  description = "Domain name for the hosted zone"
+  type        = string
+  default     = "stg-static.makedara.work"
+}


### PR DESCRIPTION
## 概要
Issue #3 に基づき、Route53ホストゾーンのTerraform構成を追加しました。

## 変更内容

### 共通モジュールの作成
- `infrastructure/modules/route53-hosted-zone/` に再利用可能なモジュールを作成
- ホストゾーンの作成、タグ管理、出力定義を実装

### ステージング環境
- ドメイン: `stg-static.makedara.work`
- `infrastructure/stg/` にTerraform構成を配置
- 共通モジュールを使用

### 本番環境
- ドメイン: `static.makedara.work`
- `infrastructure/prod/` にTerraform構成を配置
- 共通モジュールを使用

### ドキュメント
- `infrastructure/README.md` を追加し、使用方法やディレクトリ構成を記載

## 構成の特徴
- モジュール化により、共通部分を効率的に管理
- 環境ごとに独立した設定ファイルで運用
- default_tagsによる一貫したタグ管理
- 各環境で異なるAWSアカウントを使用することを想定

## テスト計画
- [ ] ステージング環境で `terraform init` が成功することを確認
- [ ] ステージング環境で `terraform plan` が正常に実行されることを確認
- [ ] 本番環境で `terraform init` が成功することを確認
- [ ] 本番環境で `terraform plan` が正常に実行されることを確認
- [ ] (任意) ステージング環境で実際にホストゾーンを作成し、動作を確認

## 注意事項
- Terraform実行前に、適切なAWS認証情報が設定されていることを確認してください
- 本番環境への適用は慎重に行ってください

Close #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- backend設定追加
- terraform init実行（.terraform.lock.hcl追加）