### PR TITLE
CloudFront用SSL証明書のTerraform構成を追加

### DIFF
--- a/infrastructure/modules/acm-certificate/main.tf
+++ b/infrastructure/modules/acm-certificate/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws]
+    }
+  }
+}
+
+resource "aws_acm_certificate" "main" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = merge(
+    {
+      Name        = var.domain_name
+      Environment = var.environment
+    },
+    var.tags
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.main.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.route53_zone_id
+}
+
+resource "aws_acm_certificate_validation" "main" {
+  certificate_arn         = aws_acm_certificate.main.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/infrastructure/modules/acm-certificate/outputs.tf
+++ b/infrastructure/modules/acm-certificate/outputs.tf
@@ -1,0 +1,19 @@
+output "certificate_arn" {
+  description = "The ARN of the certificate"
+  value       = aws_acm_certificate.main.arn
+}
+
+output "certificate_domain_name" {
+  description = "The domain name of the certificate"
+  value       = aws_acm_certificate.main.domain_name
+}
+
+output "certificate_status" {
+  description = "The status of the certificate"
+  value       = aws_acm_certificate.main.status
+}
+
+output "validation_record_fqdns" {
+  description = "The FQDNs of the validation records"
+  value       = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/infrastructure/modules/acm-certificate/variables.tf
+++ b/infrastructure/modules/acm-certificate/variables.tf
@@ -1,0 +1,20 @@
+variable "domain_name" {
+  description = "The domain name for the certificate"
+  type        = string
+}
+
+variable "route53_zone_id" {
+  description = "The Route53 hosted zone ID for DNS validation"
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment name (e.g., staging, production)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the certificate"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/prod/main.tf
+++ b/infrastructure/prod/main.tf
@@ -29,6 +29,20 @@ provider "aws" {
   }
 }
 
+# CloudFront requires ACM certificates in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = "production"
+      ManagedBy   = "Terraform"
+      Project     = "static-app"
+    }
+  }
+}
+
 module "hosted_zone" {
   source = "../modules/route53-hosted-zone"
 
@@ -37,5 +51,22 @@ module "hosted_zone" {
 
   tags = {
     Project = "static-app"
+  }
+}
+
+module "ssl_certificate" {
+  source = "../modules/acm-certificate"
+
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  domain_name      = var.ssl_domain_name
+  route53_zone_id  = module.hosted_zone.zone_id
+  environment      = "production"
+
+  tags = {
+    Project = "static-app"
+    Purpose = "CloudFront"
   }
 }

--- a/infrastructure/prod/outputs.tf
+++ b/infrastructure/prod/outputs.tf
@@ -12,3 +12,18 @@ output "hosted_zone_arn" {
   description = "The ARN of the hosted zone"
   value       = module.hosted_zone.zone_arn
 }
+
+output "ssl_certificate_arn" {
+  description = "The ARN of the SSL certificate"
+  value       = module.ssl_certificate.certificate_arn
+}
+
+output "ssl_certificate_domain" {
+  description = "The domain name of the SSL certificate"
+  value       = module.ssl_certificate.certificate_domain_name
+}
+
+output "ssl_certificate_status" {
+  description = "The status of the SSL certificate"
+  value       = module.ssl_certificate.certificate_status
+}

--- a/infrastructure/prod/variables.tf
+++ b/infrastructure/prod/variables.tf
@@ -9,3 +9,9 @@ variable "domain_name" {
   type        = string
   default     = "static.makedara.work"
 }
+
+variable "ssl_domain_name" {
+  description = "Domain name for the SSL certificate"
+  type        = string
+  default     = "apps.static.makedara.work"
+}

--- a/infrastructure/stg/main.tf
+++ b/infrastructure/stg/main.tf
@@ -29,6 +29,20 @@ provider "aws" {
   }
 }
 
+# CloudFront requires ACM certificates in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = "staging"
+      ManagedBy   = "Terraform"
+      Project     = "static-app"
+    }
+  }
+}
+
 module "hosted_zone" {
   source = "../modules/route53-hosted-zone"
 
@@ -37,5 +51,22 @@ module "hosted_zone" {
 
   tags = {
     Project = "static-app"
+  }
+}
+
+module "ssl_certificate" {
+  source = "../modules/acm-certificate"
+
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  domain_name      = var.ssl_domain_name
+  route53_zone_id  = module.hosted_zone.zone_id
+  environment      = "staging"
+
+  tags = {
+    Project = "static-app"
+    Purpose = "CloudFront"
   }
 }

--- a/infrastructure/stg/outputs.tf
+++ b/infrastructure/stg/outputs.tf
@@ -12,3 +12,18 @@ output "hosted_zone_arn" {
   description = "The ARN of the hosted zone"
   value       = module.hosted_zone.zone_arn
 }
+
+output "ssl_certificate_arn" {
+  description = "The ARN of the SSL certificate"
+  value       = module.ssl_certificate.certificate_arn
+}
+
+output "ssl_certificate_domain" {
+  description = "The domain name of the SSL certificate"
+  value       = module.ssl_certificate.certificate_domain_name
+}
+
+output "ssl_certificate_status" {
+  description = "The status of the SSL certificate"
+  value       = module.ssl_certificate.certificate_status
+}

--- a/infrastructure/stg/variables.tf
+++ b/infrastructure/stg/variables.tf
@@ -9,3 +9,9 @@ variable "domain_name" {
   type        = string
   default     = "stg-static.makedara.work"
 }
+
+variable "ssl_domain_name" {
+  description = "Domain name for the SSL certificate"
+  type        = string
+  default     = "apps.stg-static.makedara.work"
+}


### PR DESCRIPTION
## 概要
Issue #7 に基づき、CloudFront用のSSL証明書を発行するためのTerraform構成を追加しました。

## 変更内容

### 共通モジュールの作成
- `infrastructure/modules/acm-certificate/` にACM証明書モジュールを作成
- DNS検証による自動検証機能を実装
- Route53レコードの自動作成と証明書検証を含む

### ステージング環境
- ドメイン: `apps.stg-static.makedara.work`
- us-east-1リージョンで証明書を作成（CloudFront要件）
- 専用のAWSプロバイダー（us_east_1 alias）を追加

### 本番環境
- ドメイン: `apps.static.makedara.work`
- us-east-1リージョンで証明書を作成（CloudFront要件）
- 専用のAWSプロバイダー（us_east_1 alias）を追加

## 技術的な特徴

### CloudFront要件への対応
- CloudFrontで使用する証明書は必ずus-east-1リージョンに存在する必要があるため、専用プロバイダーを設定
- メインリソースはap-northeast-1、証明書はus-east-1という構成

### 自動DNS検証
- 証明書のDNS検証レコードをRoute53に自動作成
- `aws_acm_certificate_validation`リソースで検証完了まで待機
- 手動でのDNS設定は不要

### 出力値
- 証明書ARN
- 証明書ドメイン名
- 証明書ステータス

## 注意事項
- Issueの要件通り、ドメインのルーティング設定は含まれていません
- 証明書の検証には数分かかる場合があります
- terraform applyの実行には、Route53のホストゾーンが事前に作成されている必要があります

Close #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- configuration_aliasesの宣言追加