### PR TITLE
CloudFront→S3構成追加

### DIFF
--- a/infrastructure/modules/cloudfront-s3/main.tf
+++ b/infrastructure/modules/cloudfront-s3/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# CloudFront Origin Access Control
+resource "aws_cloudfront_origin_access_control" "main" {
+  name                              = "oac-${var.s3_bucket_id}"
+  description                       = "Origin Access Control for ${var.s3_bucket_id}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront Distribution
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "CloudFront distribution for ${var.domain_name}"
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+
+  origin {
+    domain_name              = var.s3_bucket_regional_domain_name
+    origin_id                = "S3-${var.s3_bucket_id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.main.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-${var.s3_bucket_id}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = merge(
+    {
+      Name        = var.domain_name
+      Environment = var.environment
+    },
+    var.tags
+  )
+}
+
+# S3 Bucket Policy to allow CloudFront access
+resource "aws_s3_bucket_policy" "cloudfront_access" {
+  bucket = var.s3_bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServicePrincipal"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::${var.s3_bucket_id}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.main.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/infrastructure/modules/cloudfront-s3/outputs.tf
+++ b/infrastructure/modules/cloudfront-s3/outputs.tf
@@ -1,0 +1,19 @@
+output "distribution_id" {
+  description = "The ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "distribution_arn" {
+  description = "The ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.main.arn
+}
+
+output "distribution_domain_name" {
+  description = "The domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "distribution_hosted_zone_id" {
+  description = "The Route53 zone ID for the CloudFront distribution"
+  value       = aws_cloudfront_distribution.main.hosted_zone_id
+}

--- a/infrastructure/modules/cloudfront-s3/variables.tf
+++ b/infrastructure/modules/cloudfront-s3/variables.tf
@@ -1,0 +1,30 @@
+variable "domain_name" {
+  description = "Domain name for the CloudFront distribution"
+  type        = string
+}
+
+variable "s3_bucket_id" {
+  description = "ID of the S3 bucket to use as origin"
+  type        = string
+}
+
+variable "s3_bucket_regional_domain_name" {
+  description = "Regional domain name of the S3 bucket"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "ARN of the ACM certificate to use for HTTPS"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., production, staging)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/modules/route53-cloudfront-record/main.tf
+++ b/infrastructure/modules/route53-cloudfront-record/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_route53_record" "main" {
+  zone_id = var.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infrastructure/modules/route53-cloudfront-record/outputs.tf
+++ b/infrastructure/modules/route53-cloudfront-record/outputs.tf
@@ -1,0 +1,9 @@
+output "record_name" {
+  description = "The name of the Route53 record"
+  value       = aws_route53_record.main.name
+}
+
+output "record_fqdn" {
+  description = "The FQDN of the Route53 record"
+  value       = aws_route53_record.main.fqdn
+}

--- a/infrastructure/modules/route53-cloudfront-record/variables.tf
+++ b/infrastructure/modules/route53-cloudfront-record/variables.tf
@@ -1,0 +1,25 @@
+variable "zone_id" {
+  description = "Route53 hosted zone ID"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name for the A record"
+  type        = string
+}
+
+variable "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  type        = string
+}
+
+variable "cloudfront_hosted_zone_id" {
+  description = "CloudFront distribution hosted zone ID"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/modules/s3-static-website/main.tf
+++ b/infrastructure/modules/s3-static-website/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "main" {
+  bucket = var.bucket_name
+
+  tags = merge(
+    {
+      Name        = var.bucket_name
+      Environment = var.environment
+    },
+    var.tags
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "main" {
+  bucket = aws_s3_bucket.main.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "main" {
+  bucket = aws_s3_bucket.main.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "main" {
+  bucket = aws_s3_bucket.main.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/infrastructure/modules/s3-static-website/outputs.tf
+++ b/infrastructure/modules/s3-static-website/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_id" {
+  description = "The ID of the S3 bucket"
+  value       = aws_s3_bucket.main.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = aws_s3_bucket.main.arn
+}
+
+output "bucket_domain_name" {
+  description = "The domain name of the S3 bucket"
+  value       = aws_s3_bucket.main.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "The regional domain name of the S3 bucket"
+  value       = aws_s3_bucket.main.bucket_regional_domain_name
+}

--- a/infrastructure/modules/s3-static-website/variables.tf
+++ b/infrastructure/modules/s3-static-website/variables.tf
@@ -1,0 +1,15 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., production, staging)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/prod/outputs.tf
+++ b/infrastructure/prod/outputs.tf
@@ -27,3 +27,23 @@ output "ssl_certificate_status" {
   description = "The status of the SSL certificate"
   value       = module.ssl_certificate.certificate_status
 }
+
+output "apps_s3_bucket_id" {
+  description = "The ID of the apps S3 bucket"
+  value       = module.apps_s3_bucket.bucket_id
+}
+
+output "apps_cloudfront_distribution_id" {
+  description = "The ID of the apps CloudFront distribution"
+  value       = module.apps_cloudfront.distribution_id
+}
+
+output "apps_cloudfront_domain_name" {
+  description = "The domain name of the apps CloudFront distribution"
+  value       = module.apps_cloudfront.distribution_domain_name
+}
+
+output "apps_route53_record_fqdn" {
+  description = "The FQDN of the apps Route53 record"
+  value       = module.apps_route53_record.record_fqdn
+}

--- a/infrastructure/stg/main.tf
+++ b/infrastructure/stg/main.tf
@@ -70,3 +70,43 @@ module "ssl_certificate" {
     Purpose = "CloudFront"
   }
 }
+
+module "apps_s3_bucket" {
+  source = "../modules/s3-static-website"
+
+  bucket_name = "apps-stg-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+  environment = "staging"
+
+  tags = {
+    Project = "static-app"
+    Purpose = "Apps hosting"
+  }
+}
+
+module "apps_cloudfront" {
+  source = "../modules/cloudfront-s3"
+
+  domain_name                    = var.ssl_domain_name
+  s3_bucket_id                   = module.apps_s3_bucket.bucket_id
+  s3_bucket_regional_domain_name = module.apps_s3_bucket.bucket_regional_domain_name
+  certificate_arn                = module.ssl_certificate.certificate_arn
+  environment                    = "staging"
+
+  tags = {
+    Project = "static-app"
+    Purpose = "Apps distribution"
+  }
+}
+
+module "apps_route53_record" {
+  source = "../modules/route53-cloudfront-record"
+
+  zone_id                    = module.hosted_zone.zone_id
+  domain_name                = var.ssl_domain_name
+  cloudfront_domain_name     = module.apps_cloudfront.distribution_domain_name
+  cloudfront_hosted_zone_id  = module.apps_cloudfront.distribution_hosted_zone_id
+
+  tags = {
+    Project = "static-app"
+  }
+}

--- a/infrastructure/stg/outputs.tf
+++ b/infrastructure/stg/outputs.tf
@@ -27,3 +27,23 @@ output "ssl_certificate_status" {
   description = "The status of the SSL certificate"
   value       = module.ssl_certificate.certificate_status
 }
+
+output "apps_s3_bucket_id" {
+  description = "The ID of the apps S3 bucket"
+  value       = module.apps_s3_bucket.bucket_id
+}
+
+output "apps_cloudfront_distribution_id" {
+  description = "The ID of the apps CloudFront distribution"
+  value       = module.apps_cloudfront.distribution_id
+}
+
+output "apps_cloudfront_domain_name" {
+  description = "The domain name of the apps CloudFront distribution"
+  value       = module.apps_cloudfront.distribution_domain_name
+}
+
+output "apps_route53_record_fqdn" {
+  description = "The FQDN of the apps Route53 record"
+  value       = module.apps_route53_record.record_fqdn
+}


### PR DESCRIPTION
## 概要

Issue #11 に基づき、CloudFrontとS3を使用したアプリ配信インフラを追加しました。

## 変更内容

### 新規モジュール作成

- **s3-static-website**: S3バケットを管理するモジュール
  - バケット作成
  - バージョニング有効化
  - サーバーサイド暗号化設定
  - パブリックアクセスブロック設定

- **cloudfront-s3**: CloudFront配信を管理するモジュール
  - CloudFront Distribution作成
  - Origin Access Control設定
  - S3バケットポリシー設定
  - HTTPS強制リダイレクト

- **route53-cloudfront-record**: Route53レコードを管理するモジュール
  - CloudFrontへのAliasレコード作成

### 環境別設定追加

#### prod環境
- S3バケット: `apps-prod-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066`
- ドメイン: `apps.static.makedara.work`
- 既存のSSL証明書を使用

#### stg環境
- S3バケット: `apps-stg-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066`
- ドメイン: `apps.stg-static.makedara.work`
- 既存のSSL証明書を使用

## デプロイ手順

1. 各環境で `terraform init` を実行
2. 各環境で `terraform plan` で変更内容を確認
3. 各環境で `terraform apply` を実行

Close #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)