### PR TITLE
九九練習アプリを追加

### DIFF
--- a/application/kuku/css/style.css
+++ b/application/kuku/css/style.css
@@ -1,0 +1,67 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body, html {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    font-family: 'Arial', 'Hiragino Sans', 'Meiryo', sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#app {
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+}
+
+.display {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 20vmin;
+    font-weight: bold;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.hidden {
+    display: none;
+}
+
+#question {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+#answer {
+    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    color: white;
+    text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
+    animation: scaleIn 0.2s ease-out;
+}
+
+@keyframes scaleIn {
+    0% {
+        transform: scale(0.8);
+        opacity: 0;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+/* タッチデバイス対応 */
+@media (hover: none) and (pointer: coarse) {
+    body {
+        touch-action: manipulation;
+    }
+}

--- a/application/kuku/index.html
+++ b/application/kuku/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>九九練習アプリ</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div id="app">
+        <div id="question" class="display">9×8=</div>
+        <div id="answer" class="display hidden">72</div>
+    </div>
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/application/kuku/js/app.js
+++ b/application/kuku/js/app.js
@@ -1,0 +1,69 @@
+// 九九練習アプリ
+class KukuApp {
+    constructor() {
+        this.questionEl = document.getElementById('question');
+        this.answerEl = document.getElementById('answer');
+        this.isShowingAnswer = false;
+
+        // 初期化
+        this.init();
+    }
+
+    init() {
+        // 最初の問題を生成
+        this.generateNewQuestion();
+
+        // クリック・タップイベントを設定
+        document.addEventListener('click', () => this.handleClick());
+        document.addEventListener('touchstart', (e) => {
+            e.preventDefault();
+            this.handleClick();
+        });
+    }
+
+    // ランダムな九九の問題を生成
+    generateNewQuestion() {
+        const num1 = Math.floor(Math.random() * 9) + 1; // 1-9
+        const num2 = Math.floor(Math.random() * 9) + 1; // 1-9
+        const answer = num1 * num2;
+
+        this.currentQuestion = `${num1}×${num2}=`;
+        this.currentAnswer = String(answer);
+
+        // 問題を表示
+        this.showQuestion();
+    }
+
+    // 問題を表示
+    showQuestion() {
+        this.questionEl.textContent = this.currentQuestion;
+        this.questionEl.classList.remove('hidden');
+        this.answerEl.classList.add('hidden');
+        this.isShowingAnswer = false;
+    }
+
+    // 答えを表示
+    showAnswer() {
+        this.answerEl.textContent = this.currentAnswer;
+        this.answerEl.classList.remove('hidden');
+        this.questionEl.classList.add('hidden');
+        this.isShowingAnswer = true;
+
+        // 0.5秒後に次の問題を表示
+        setTimeout(() => {
+            this.generateNewQuestion();
+        }, 500);
+    }
+
+    // クリック・タップ処理
+    handleClick() {
+        if (!this.isShowingAnswer) {
+            this.showAnswer();
+        }
+    }
+}
+
+// アプリを起動
+document.addEventListener('DOMContentLoaded', () => {
+    new KukuApp();
+});


### PR DESCRIPTION
## 概要

Issue #13 に基づき、九九の練習ができるWebアプリを作成しました。

## 実装内容

### ディレクトリ構成
```
application/kuku/
├── index.html
├── js/
│   └── app.js
└── css/
    └── style.css
```

### 機能

- **問題表示**: ランダムな九九の問題（1×1から9×9）を画面いっぱいに表示
- **答え表示**: 画面をタップまたはクリックすると答えが表示される
- **自動遷移**: 答え表示後、0.5秒で次の問題が自動的に表示される
- **タッチ対応**: スマートフォン・タブレットでのタッチ操作に対応

### デザイン

- グラデーション背景（問題：紫系、答え：ピンク系）
- スケールアニメーションで視覚的なフィードバック
- レスポンシブフォントサイズ（画面サイズに応じて自動調整）
- 影付き文字で視認性向上

### 技術仕様

- バニラJavaScript（クラスベース設計）
- CSS3アニメーション
- タッチイベントとクリックイベントの両対応
- ビューポート単位（vmin）による完全レスポンシブ対応

## 動作確認

ブラウザで `application/kuku/index.html` を開いて動作確認できます。

Close #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)