### PR TITLE
スラッシュ終わりのURL対応

### DIFF
--- a/infrastructure/modules/cloudfront-s3/url-rewrite-function.js
+++ b/infrastructure/modules/cloudfront-s3/url-rewrite-function.js
@@ -1,0 +1,15 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // URIがスラッシュで終わる場合、index.htmlを追加
+    if (uri.endsWith('/')) {
+        request.uri += 'index.html';
+    }
+    // URIにファイル拡張子がない場合もindex.htmlを追加
+    else if (!uri.includes('.')) {
+        request.uri += '/index.html';
+    }
+
+    return request;
+}


### PR DESCRIPTION
## 概要
Issue #17 の対応として、URLがスラッシュで終わる場合に自動的にindex.htmlが読み込まれる機能を実装しました。

## 変更内容
- **CloudFront Function の追加**: URL書き換え用の関数を実装
- **Terraform設定の更新**: CloudFront Distributionにfunction_associationを追加
- **URL書き換えロジック**: 
  - URLがスラッシュで終わる場合: `/path/` → `/path/index.html`
  - 拡張子がない場合: `/path` → `/path/index.html`

## 実装方法
CloudFront Functionsを使用して、viewer-requestイベント時にURLを書き換えています。

## テスト方法
1. Terraformでインフラを適用
2. スラッシュで終わるURLにアクセスして、index.htmlが表示されることを確認

Close #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)