### PR TITLE
stgドメインをstatic-stg.makedara.workに変更

### DIFF
--- a/infrastructure/stg/variables.tf
+++ b/infrastructure/stg/variables.tf
@@ -7,11 +7,11 @@ variable "aws_region" {
 variable "domain_name" {
   description = "Domain name for the hosted zone"
   type        = string
-  default     = "stg-static.makedara.work"
+  default     = "static-stg.makedara.work"
 }
 
 variable "ssl_domain_name" {
   description = "Domain name for the SSL certificate"
   type        = string
-  default     = "apps.stg-static.makedara.work"
+  default     = "apps.static-stg.makedara.work"
 }


### PR DESCRIPTION
## 変更内容

`infrastructure/stg/variables.tf` のドメイン設定を変更しました。

- `domain_name`: `stg-static.makedara.work` → `static-stg.makedara.work`
- `ssl_domain_name`: `apps.stg-static.makedara.work` → `apps.static-stg.makedara.work`

Close #23