### PR TITLE
refactor: ssl_domain_name変数廃止・UUID変数化

### DIFF
--- a/infrastructure/prod/main.tf
+++ b/infrastructure/prod/main.tf
@@ -61,7 +61,7 @@ module "ssl_certificate" {
     aws = aws.us_east_1
   }
 
-  domain_name      = var.ssl_domain_name
+  domain_name      = "apps.${var.domain_name}"
   route53_zone_id  = module.hosted_zone.zone_id
   environment      = "production"
 
@@ -74,7 +74,7 @@ module "ssl_certificate" {
 module "apps_s3_bucket" {
   source = "../modules/s3-static-website"
 
-  bucket_name = "apps-prod-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+  bucket_name = "apps-prod-${var.uuid}"
   environment = "production"
 
   tags = {
@@ -86,7 +86,7 @@ module "apps_s3_bucket" {
 module "apps_cloudfront" {
   source = "../modules/cloudfront-s3"
 
-  domain_name                    = var.ssl_domain_name
+  domain_name                    = "apps.${var.domain_name}"
   s3_bucket_id                   = module.apps_s3_bucket.bucket_id
   s3_bucket_regional_domain_name = module.apps_s3_bucket.bucket_regional_domain_name
   certificate_arn                = module.ssl_certificate.certificate_arn
@@ -103,7 +103,7 @@ module "apps_route53_record" {
   source = "../modules/route53-cloudfront-record"
 
   zone_id                    = module.hosted_zone.zone_id
-  domain_name                = var.ssl_domain_name
+  domain_name                = "apps.${var.domain_name}"
   cloudfront_domain_name     = module.apps_cloudfront.distribution_domain_name
   cloudfront_hosted_zone_id  = module.apps_cloudfront.distribution_hosted_zone_id
 
@@ -119,7 +119,7 @@ module "memo_ssl_certificate" {
     aws = aws.us_east_1
   }
 
-  domain_name     = "memo.static.makedara.work"
+  domain_name     = "memo.${var.domain_name}"
   route53_zone_id = module.hosted_zone.zone_id
   environment     = "production"
 
@@ -132,7 +132,7 @@ module "memo_ssl_certificate" {
 module "memo_s3_bucket" {
   source = "../modules/s3-static-website"
 
-  bucket_name = "memo-prod-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+  bucket_name = "memo-prod-${var.uuid}"
   environment = "production"
 
   tags = {
@@ -144,7 +144,7 @@ module "memo_s3_bucket" {
 module "memo_cloudfront" {
   source = "../modules/cloudfront-s3"
 
-  domain_name                    = "memo.static.makedara.work"
+  domain_name                    = "memo.${var.domain_name}"
   s3_bucket_id                   = module.memo_s3_bucket.bucket_id
   s3_bucket_regional_domain_name = module.memo_s3_bucket.bucket_regional_domain_name
   certificate_arn                = module.memo_ssl_certificate.certificate_arn
@@ -161,7 +161,7 @@ module "memo_route53_record" {
   source = "../modules/route53-cloudfront-record"
 
   zone_id                   = module.hosted_zone.zone_id
-  domain_name               = "memo.static.makedara.work"
+  domain_name               = "memo.${var.domain_name}"
   cloudfront_domain_name    = module.memo_cloudfront.distribution_domain_name
   cloudfront_hosted_zone_id = module.memo_cloudfront.distribution_hosted_zone_id
 

--- a/infrastructure/prod/variables.tf
+++ b/infrastructure/prod/variables.tf
@@ -10,8 +10,8 @@ variable "domain_name" {
   default     = "static.makedara.work"
 }
 
-variable "ssl_domain_name" {
-  description = "Domain name for the SSL certificate"
+variable "uuid" {
+  description = "Unique identifier for resource names"
   type        = string
-  default     = "apps.static.makedara.work"
+  default     = "675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
 }

--- a/infrastructure/stg/main.tf
+++ b/infrastructure/stg/main.tf
@@ -61,7 +61,7 @@ module "ssl_certificate" {
     aws = aws.us_east_1
   }
 
-  domain_name      = var.ssl_domain_name
+  domain_name      = "apps.${var.domain_name}"
   route53_zone_id  = module.hosted_zone.zone_id
   environment      = "staging"
 
@@ -74,7 +74,7 @@ module "ssl_certificate" {
 module "apps_s3_bucket" {
   source = "../modules/s3-static-website"
 
-  bucket_name = "apps-stg-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+  bucket_name = "apps-stg-${var.uuid}"
   environment = "staging"
 
   tags = {
@@ -86,7 +86,7 @@ module "apps_s3_bucket" {
 module "apps_cloudfront" {
   source = "../modules/cloudfront-s3"
 
-  domain_name                    = var.ssl_domain_name
+  domain_name                    = "apps.${var.domain_name}"
   s3_bucket_id                   = module.apps_s3_bucket.bucket_id
   s3_bucket_regional_domain_name = module.apps_s3_bucket.bucket_regional_domain_name
   certificate_arn                = module.ssl_certificate.certificate_arn
@@ -103,7 +103,7 @@ module "apps_route53_record" {
   source = "../modules/route53-cloudfront-record"
 
   zone_id                    = module.hosted_zone.zone_id
-  domain_name                = var.ssl_domain_name
+  domain_name                = "apps.${var.domain_name}"
   cloudfront_domain_name     = module.apps_cloudfront.distribution_domain_name
   cloudfront_hosted_zone_id  = module.apps_cloudfront.distribution_hosted_zone_id
 
@@ -119,7 +119,7 @@ module "memo_ssl_certificate" {
     aws = aws.us_east_1
   }
 
-  domain_name     = "memo.static-stg.makedara.work"
+  domain_name     = "memo.${var.domain_name}"
   route53_zone_id = module.hosted_zone.zone_id
   environment     = "staging"
 
@@ -132,7 +132,7 @@ module "memo_ssl_certificate" {
 module "memo_s3_bucket" {
   source = "../modules/s3-static-website"
 
-  bucket_name = "memo-stg-675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
+  bucket_name = "memo-stg-${var.uuid}"
   environment = "staging"
 
   tags = {
@@ -144,7 +144,7 @@ module "memo_s3_bucket" {
 module "memo_cloudfront" {
   source = "../modules/cloudfront-s3"
 
-  domain_name                    = "memo.static-stg.makedara.work"
+  domain_name                    = "memo.${var.domain_name}"
   s3_bucket_id                   = module.memo_s3_bucket.bucket_id
   s3_bucket_regional_domain_name = module.memo_s3_bucket.bucket_regional_domain_name
   certificate_arn                = module.memo_ssl_certificate.certificate_arn
@@ -161,7 +161,7 @@ module "memo_route53_record" {
   source = "../modules/route53-cloudfront-record"
 
   zone_id                   = module.hosted_zone.zone_id
-  domain_name               = "memo.static-stg.makedara.work"
+  domain_name               = "memo.${var.domain_name}"
   cloudfront_domain_name    = module.memo_cloudfront.distribution_domain_name
   cloudfront_hosted_zone_id = module.memo_cloudfront.distribution_hosted_zone_id
 

--- a/infrastructure/stg/variables.tf
+++ b/infrastructure/stg/variables.tf
@@ -10,8 +10,8 @@ variable "domain_name" {
   default     = "static-stg.makedara.work"
 }
 
-variable "ssl_domain_name" {
-  description = "Domain name for the SSL certificate"
+variable "uuid" {
+  description = "Unique identifier for resource names"
   type        = string
-  default     = "apps.static-stg.makedara.work"
+  default     = "675f09ae-9bb8-4d10-b5f2-77c2f1bb1066"
 }


### PR DESCRIPTION
## 変更内容

- `ssl_domain_name` 変数を `variables.tf` から削除し、`main.tf` 内で `"apps.${var.domain_name}"` として直接導出する形に変更
- UUID `675f09ae-9bb8-4d10-b5f2-77c2f1bb1066` を `uuid` 変数として `variables.tf` で管理するように変更
- `main.tf` でハードコードされていた `memo.*` ドメインをすべて `"memo.${var.domain_name}"` に置換
- S3バケット名のUUIDを `var.uuid` に置換（`backend "s3"` ブロックはTerraform仕様上、変数補間不可のため除く）
- prod / stg 両環境に適用

`terraform plan` の差分はゼロ（インフラ構成・設定値変更なし）。

Close #31